### PR TITLE
Add GitHub releases to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,3 +37,25 @@ jobs:
           else
             deno publish
           fi
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref }}
+          name: Release ${{ steps.get_version.outputs.version }}
+          body: |
+            ## Release ${{ steps.get_version.outputs.version }}
+
+            Published to JSR: [@theswanfactory/deno-hooks@${{ steps.get_version.outputs.version }}](https://jsr.io/@theswanfactory/deno-hooks@${{ steps.get_version.outputs.version }})
+
+            ### Installation
+
+            ```bash
+            deno add @theswanfactory/deno-hooks@${{ steps.get_version.outputs.version }}
+            ```
+
+            See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/${{ github.ref_name }}/CHANGELOG.md) for details.
+          draft: false
+          prerelease: ${{ contains(steps.get_version.outputs.version, '-dev.') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: read
+      contents: write # Required for creating releases
       id-token: write # Required for OIDC authentication with JSR
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ### Added
 
+- Now properly creates releases
 - Self-contained hook scripts that work without deno-hooks installed
 - Support for any shell command in hooks (not just deno commands)
 - Success message "✓ All hooks passed" after successful hook execution

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,16 +207,44 @@ deno task version patch  # 0.3.0 -> 0.3.1
 deno task version minor  # 0.3.0 -> 0.4.0
 deno task version major  # 0.3.0 -> 1.0.0
 
-# Create and push release tag
+# Create and push dev pre-release tag (timestamp-based, merge-safe)
+deno task version dev    # 0.3.0 -> 0.3.0-dev.1734293847
+
+# Reset from dev version to stable
+deno task version reset  # 0.3.0-dev.1734293847 -> 0.3.0
+
+# Create and push stable release tag
 deno task version tag
 
 # Show help
 deno task version help
 ```
 
+**Dev Versioning**: Dev releases use timestamp-based identifiers (epoch seconds)
+like `0.3.0-dev.1734293847`. This ensures monotonic, merge-safe versions that
+won't conflict when multiple branches create dev releases simultaneously.
+
 ### Release Workflow
 
-#### Option 1: Automated version bump
+#### Dev Pre-release (for testing)
+
+Use dev releases to test JSR publication before stable releases:
+
+1. Create dev release: `deno task version dev`
+   - Generates timestamp-based version (e.g., `0.3.0-dev.1734293847`)
+   - Commits, tags, and pushes automatically
+2. Test the dev release:
+   `deno run -A jsr:@theswanfactory/deno-hooks@0.3.0-dev.1734293847`
+3. Reset to stable: `deno task version reset`
+   - Removes `-dev.timestamp` suffix
+   - Commits and pushes automatically
+
+**Note**: You cannot bump versions while on a dev/prerelease version. You must
+reset to stable first.
+
+#### Stable Release
+
+##### Option 1: Automated version bump
 
 1. Update version: `deno task version major` (for v1.0.0)
 2. Update `CHANGELOG.md` (move changes from `[Unreleased]` to new version)
@@ -224,7 +252,7 @@ deno task version help
 4. Push: `git push`
 5. Create tag: `deno task version tag`
 
-#### Option 2: Manual version in deno.json
+##### Option 2: Manual version in deno.json
 
 1. Edit `deno.json` to change version manually
 2. Update `CHANGELOG.md` (move changes from `[Unreleased]` to new version)

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@theswanfactory/deno-hooks",
-  "version": "0.3.0-dev.1765826058",
+  "version": "0.3.0",
   "exports": {
     ".": "./src/mod.ts"
   },

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@theswanfactory/deno-hooks",
-  "version": "0.3.0",
+  "version": "0.3.0-dev.1765826450",
   "exports": {
     ".": "./src/mod.ts"
   },

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@theswanfactory/deno-hooks",
-  "version": "0.3.0-dev.1765826450",
+  "version": "0.3.0-dev.1765827924",
   "exports": {
     ".": "./src/mod.ts"
   },

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@theswanfactory/deno-hooks",
-  "version": "0.3.0-dev.1765827924",
+  "version": "0.3.0",
   "exports": {
     ".": "./src/mod.ts"
   },

--- a/deno.json
+++ b/deno.json
@@ -33,6 +33,7 @@
     "@std/path": "jsr:@std/path@^1.0.8",
     "@std/fs": "jsr:@std/fs@^1.0.8",
     "@std/expect": "jsr:@std/expect@^1.0.8",
+    "@std/semver": "jsr:@std/semver@^1.0.3",
     "deno-hooks": "./src/mod.ts"
   },
   "__comments": {

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@theswanfactory/deno-hooks",
-  "version": "0.3.0",
+  "version": "0.3.0-dev.1765826058",
   "exports": {
     ".": "./src/mod.ts"
   },


### PR DESCRIPTION
## Summary

- GitHub workflow now creates releases automatically when publishing to JSR
- Fixed workflow permissions to allow release creation
- Added @std/semver dependency for version management
- Updated version.ts to use @std/semver for better version handling

## Changes

### GitHub Actions Workflow
- Added `contents: write` permission (required for creating releases)
- Added "Create GitHub Release" step using `softprops/action-gh-release@v2`
- Automatically marks dev versions as pre-releases
- Includes JSR package link and installation instructions in release body

### Version Management
- Refactored `scripts/version.ts` to use `@std/semver` for version parsing
- Added `@std/semver` to `deno.json` imports
- Improved error handling and validation

### Documentation
- Updated `CLAUDE.md` with dev versioning details
- Updated `CHANGELOG.md`

## Test Results

Successfully tested with dev pre-release:
- ✅ JSR publication works
- ✅ GitHub release created automatically
- ✅ Pre-release flag correctly set for dev versions
- ✅ Release includes JSR link and installation instructions

See: https://github.com/TheSwanFactory/deno-hooks/releases/tag/v0.3.0-dev.1765827924

## Next Steps

After merge, stable releases created with `deno task version tag` will also generate GitHub releases automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)